### PR TITLE
Plated elites fixed

### DIFF
--- a/NemesisSpikestrip/Changes/Plated.cs
+++ b/NemesisSpikestrip/Changes/Plated.cs
@@ -57,15 +57,23 @@ namespace NemesisSpikestrip.Changes
                     {
                         if (victim.HasBuff(Stack))
                         {
-                            damageInfo.rejected = true;
+                            damageInfo.rejected = false;
                             EffectData effectData = new()
                             {
                                 origin = damageInfo.position,
                                 rotation = Util.QuaternionSafeLookRotation((damageInfo.force != Vector3.zero) ? damageInfo.force : Random.onUnitSphere)
                             };
-                            EffectManager.SpawnEffect(newPlatedBlockEffectPrefab, effectData, transmit: true);
+                            
                             victim.AddBuff(Stack);
-                            if (victim.GetBuffCount(Stack) >= Hits.Value) victim.SetBuffCount(Stack.buffIndex, 0);
+                            if (victim.GetBuffCount(Stack) >= Hits.Value)
+                            {
+
+                                damageInfo.rejected = true;
+                                EffectManager.SpawnEffect(newPlatedBlockEffectPrefab, effectData, transmit: true);
+                                victim.SetBuffCount(Stack.buffIndex, 0);
+                                
+                            }
+                                
                         }
                         else victim.AddBuff(Stack);
                     }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Also try: [Nemesis Rising Tides](https://thunderstore.io/package/prodzpod/Nemesi
 
 ## T1: Plated Elites <img src="https://cdn.discordapp.com/attachments/515678914316861451/1131485914137382953/texBuffAffixPlated.png" width="24">
 ![Elite](https://cdn.discordapp.com/attachments/515678914316861451/1131484732497088543/20230720155028_1.png)
-- Reworked: Upon damage, increases its stack. only the 6th attack deals damage and resets the stack.
+- Reworked: Hitting the elite adds 1 stack of the debuff. When the debuff reaches the 6th stack, the enemy will block the next attack.
 - On death, provides small amounts of armor to enemies around itself. (buff to compensate)
 - Stack is visible in health, hopefully makes the effect less frustrating to deal with.
 


### PR DESCRIPTION
Plated rework allegedly is supposed to work like this instead, so I fixed it

See: 
![image](https://github.com/prodzpod/NemesisSpikestrip/assets/94833976/d2808179-b304-4f49-ba1f-7025989aeca6)

also changed some wording in the readme to make it easier to understand what the plated elite rework does 